### PR TITLE
Added SharePoint Online check

### DIFF
--- a/oneplaceSolutionsSite-Config-v1.ps1
+++ b/oneplaceSolutionsSite-Config-v1.ps1
@@ -10,8 +10,14 @@ try {
     $SharePointUrl = Read-Host -Prompt 'Enter the url of your OnePlace Solutions Site'
         
     #Connect to newly created site collection
-    Write-Host "Enter SharePoint credentials(your email address if SharePoint Online or domain\username if on-premise):" -ForegroundColor Green  
-    Connect-pnpOnline -url $SharePointUrl    
+    If($SharePointUrl -match ".sharepoint.com/"){
+        Write-Host "Enter SharePoint credentials(your email address for SharePoint Online):" -ForegroundColor Green  
+        Connect-pnpOnline -url $SharePointUrl -UseWebLogin
+    }
+    Else{
+        Write-Host "Enter SharePoint credentials(domain\username for on-premise):" -ForegroundColor Green  
+        Connect-pnpOnline -url $SharePointUrl 
+    }
 
     #Download OnePlace Solutions Site provisioning template   
     $WebClient = New-Object System.Net.WebClient   


### PR DESCRIPTION
Added check for SharePoint Online to use the 'Web Login' in case MFA is on, from the PnP Github:

`Or if you have Multi Factor Authentication enabled or if you are using a federated identity provider like AD FS, instead use:

Connect-PnPOnline –Url https://yoursite.sharepoint.com –UseWebLogin`