### PR TITLE
Adjusting SPOMS calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@
     Windows 10/8.1 and Windows Server 2012 and greater are all ready to go, but Windows 7 is preinstalled with PowerShell v2.0 and will need to be  upgraded. This can be done by [downloading and installing the Windows Management Framework 4.0](https://www.microsoft.com/en-au/download/details.aspx?id=40855). Download and install either the x64 or x86 version based on your version of Windows 7.
 
     ![](./README-Images/image1.png)
+3.  (SharePoint Online Only) [The latest SharePoint Online Management Shell](https://www.microsoft.com/en-au/download/details.aspx?id=35588)
 
-3.  The latest [SharePoint PnP PowerShell cmdlets](https://github.com/SharePoint/PnP-PowerShell/releases). You will need to install the the cmdlets that target your version of SharePoint.
+4.  The latest [SharePoint PnP PowerShell cmdlets](https://github.com/SharePoint/PnP-PowerShell/releases). You will need to install the the cmdlets that target your version of SharePoint.
 
     ![](./README-Images/image2.png)
 

--- a/oneplaceSolutionsSite-Config-v3-SPO-modern.ps1
+++ b/oneplaceSolutionsSite-Config-v3-SPO-modern.ps1
@@ -13,7 +13,7 @@ $script:forceProvision = $false
 
 #Set this to $true to use only the PnP auth, set to $false to use SharePoint Online Management Shell auth
 #Default: $true
-$script:onlyPnP = $true
+$script:onlyPnP = $false
 
 #Set this to $false to skip automatically creating the site. This will require manual creation of the site prior to running the script.
 #Default: $true
@@ -23,11 +23,7 @@ $script:doSiteCreation = $true
 #Default: $true
 $script:doModern = $true
 
-Write-Host "Beginning script. Logging script actions to $script:logPath" -ForegroundColor Cyan
-Start-Sleep -Seconds 3
-Try{
-    Set-ExecutionPolicy Bypass -Scope Process
-    function Write-Log { 
+function Write-Log { 
         <#
         .NOTES 
             Created by: Jason Wasser @wasserja 
@@ -103,6 +99,11 @@ Try{
         } 
     }
 
+Write-Host "Beginning script. Logging script actions to $script:logPath" -ForegroundColor Cyan
+Start-Sleep -Seconds 3
+Try{
+    Set-ExecutionPolicy Bypass -Scope Process
+    
     Try { 
         function Send-OutlookEmail ($attachment,$body){
             Try{
@@ -199,11 +200,11 @@ Try{
                     Connect-PnPOnline -Url $adminSharePoint -UseWebLogin
                 }
                 Else{
-                    Connect-SPOService -url $adminSharePoint
-                    Write-Host "Passing authentication from SharePoint Online Management Shell to SharePoint PnP..."
-                    Start-Sleep -Seconds 3
                     Connect-PnPOnline -Url $adminSharePoint -SPOManagementShell
-                    Get-SPOSite | Out-Null
+                    Start-Sleep -Seconds 5
+                    #PnP doesn't wait for SPO Management Shell to complete it's login, have to pause here
+                    Pause
+                    Get-PnPWeb | Out-Null
                 }
             }
             Catch{
@@ -220,9 +221,6 @@ Try{
                     Throw $_
                 }
             }
-        }
-        Else{
-            $script:onlyPnP = $true
         }
     
         $solutionsSite = $solutionsSite.Trim()


### PR DESCRIPTION
PnP now implicitly calls SPOMS for auth, instead of us explicitly calling it beforehand and telling PnP to use what we already setup.
Skipping site creation no longer implies PnP auth only, in line with the change above.
Moved logging functions outside of main script block for consistency.